### PR TITLE
Better time resolution in performance output

### DIFF
--- a/lib/cucumber/formatter/nagios.rb
+++ b/lib/cucumber/formatter/nagios.rb
@@ -40,7 +40,7 @@ module Cucumber
       def print_summary
         @total    = @failed.size + @passed.size + @warning.size
         @status   = @failed.size > 0 && "CRITICAL" || @warning.size > 0 && "WARNING" || "OK"
-        @run_time = (Time.now - @start_time).to_i
+        @run_time = (Time.now - @start_time).round(2)
 
         service_output   = [ "CUCUMBER #{@status} - Critical: #{@failed.size}",
                              "Warning: #{@warning.size}", "#{@passed.size} okay" ]


### PR DESCRIPTION
Uses round(2) to get better execution time resolution in the performance data that gets returned to nagios. 
